### PR TITLE
Created server class for OSDC_server

### DIFF
--- a/computer/linux_server.py
+++ b/computer/linux_server.py
@@ -2,9 +2,14 @@ import os, re
 from process import RemoteProcess
 from server import SizelessConnectableServer
 
+
 class RemoteLinuxProcess(RemoteProcess):
     def __init__(self, server, pid, logfile):
         super(RemoteLinuxProcess, self).__init__(server, pid, logfile)
+
+    def __str__(self):
+        return self.server.utup[0] + ',' + self.server.utup[1] + ',' + str(self.pid) + ',' + self.logfile
+        # JK_Note: Use for db representation in django server.
 
     def is_running(self):
         "Returns bool."

--- a/computer/login_server.py
+++ b/computer/login_server.py
@@ -12,7 +12,7 @@ class LoginServer(ParamikoServer):
     def connect(self):
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(self.credentials['domain'], username=self.credentials['username'], password=self.credentials['password'])
+        client.connect(self.credentials['domain'], username=self.credentials['userName'], password=self.credentials['password'])
 
         # Open up a session
         s = client.get_transport().open_session()

--- a/computer/osdc_server.py
+++ b/computer/osdc_server.py
@@ -23,62 +23,89 @@ class OSDCServer(ParamikoServer):
         super(OSDCServer, self).__init__(utup, cpus, roots, credentials)
 
     def connect(self):
-        # Logging into the OSDC server requires adding ssh identity to ssh-agent first.
-        # If there's an existing agent, just find its name and use it, instead of creating a new one.
-        # Only create a new one when all the existing ssh-agent failed.
-        # "Using" a ssh-agent means setting the shell variable SSH_AUTH_SOCK to its tmp file.
-        retCode = 1
-        try_count = 0
-        while retCode != 0:
-            sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
-            for i in len(sshAgentList):
-                os.environ['SSH_AUTH_SOCK'] = sshAgentList[i]
-                retCode = os.system("ssh-add /var/www/jongkaishackleton-www.pem")
-                if retCode == 0:
-                    break
-            if retCode != 0:
-                os.system("ssh-agent -s")
-            if try_count > 99:
-                raise SystemExit("Cannot add ssh identity!")
-            try_count += 1
+        '''
+        Before looking into how this class is implemented, reader should look at login_server.py to see an easier implementation.
 
-        # Other setups are similar to using paramiko to login to shackleton.
-        client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(self.credentials['loginnode'], username=self.credentials['username'])
-        s = client.get_transport().open_session()
-        paramiko.agent.AgentRequestHandler(s)
-        s.get_pty()
-        s.invoke_shell()
-        self.client = client
-        self.session = s
+        Logging into the OSDC server are two-stages: 
+        1. Logging into griffin, the login node
+        2. From griffin, do a run_command to get into the computation node. This step is presumably less reliable, 
+           as it is not really handled by paramiko. But we do this regardlessly for current stage due to the fact
+           that we don't really know how to implement port-forwarding and that we have less control over Shackleton.
 
-        # Except for having to manually login into computation node.
-        stdout, stderr = self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
+        Since there are two stages of connecting, for the consistency of caller's behavior, this method would handle the
+        connection for both stages. It will first check the hostname of the current machine, then decide what to do accordingly.
+
+        Also, the way we forward authentication agent requires adding ssh identity to ssh-agent first. 
+        Here's how we do this:
+            If there's an existing agent, just find its name and use it, instead of creating a new one.
+            Only create a new one when all the existing ssh-agent failed.
+            "Using" a ssh-agent means setting the shell variable SSH_AUTH_SOCK to its tmp file.
+        '''
+        stdout = os.popen("hostname").read().strip()
+        if stdout == self.credentials['instanceName']:
+            self.connected = True
+            return "success"
+        elif stdout == "shackleton":
+            retCode = 1
+            try_count = 0
+            try:
+                while retCode != 0:
+                    sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
+                    for i in range(len(sshAgentList)):
+                        os.environ['SSH_AUTH_SOCK'] = sshAgentList[i]
+                        retCode = os.system("ssh-add " + self.credentials['pem'])
+                        if retCode == 0:
+                            break
+                    if retCode != 0:
+                        os.system("ssh-agent -s")
+                    if try_count > 99:
+                        raise paramiko.ssh_exception.AuthenticationException("Cannot add ssh identity!")
+                    try_count += 1
+            except paramiko.ssh_exception.AuthenticationException as err:
+                return err
+
+            # Following steps are similar to using paramiko to login to shackleton.
+            client = paramiko.SSHClient()
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            client.connect(self.credentials['loginNode'], username=self.credentials['userName'])
+            s = client.get_transport().open_session()
+            paramiko.agent.AgentRequestHandler(s)
+            s.get_pty()
+            s.invoke_shell()
+            self.client = client
+            self.session = s
+        
+        # Error catching if something weird happens, the hostname should never be anything else than this 3.
+        elif stdout != self.credentials['loginNode']:
+            raise paramiko.ssh_exception.AuthenticationException("This should never happen!")
+
+        # Second stage, unreliably login into computation node with run_command. 
+        # If the connection from loginNode to computation is dropped, the Hostname should be the loginNode, 
+        # then only this stage would be executed.
+        stdout, stderr = self.run_command('ssh -A ubuntu@' + self.credentials['instanceIP'])
         stdout, stderr = self.run_command('date "+%H:%M:%S   %d/%m/%y" >> arrived')
-
         self.connected = True
+        return "success"
 
     def check_connection(self):
-        # This method checks both the connection to login node and the computation node.
-        # If connection to computation node is dropped, retry.
-        # But not worry about reconnection to login node, which would be handle by the caller.
-        # This design is for the consistency of caller's behavior.
+        '''
+        This method checks both the connection to login node and the computation node.
+        If connection to computation node is dropped, "self.connected" might not be changed, so have to do manual checking here.
+        But not worry about reconnection, that should be handle by the caller, by calling server.connect().
+        '''
         if not self.connected:
             return False
-        while True:
+        else:
             # Log the arrive time for manual checking, if this time info appears in login node,
             # then I know the connection to computation node had dropped;
             # if this info appears in shackleton, then I know that not only the connection to login node had dropped, 
             # but also the self.connected is not performing as expected.
             self.run_command('date "+%H:%M:%S   %d/%m/%y" >> arrived')
 
-            # If hostname is shackleton, then the connection to login node is dropped, should reconnect.
+            # If hostname is the computation node, then the connection is good. All else situations the connection is dropped, should reconnect.
             stdout, stderr = self.run_command("hostname")
-            if stdout == "shackleton":
-                return False
-            elif stdout == "conflicts":
+            if stdout == self.credentials['instanceName']:
                 return True
             else:
-                self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
-                time.sleep(0.2)
+                self.connected = False
+                return False

--- a/computer/osdc_server.py
+++ b/computer/osdc_server.py
@@ -23,20 +23,74 @@ class OSDCServer(ParamikoServer):
         super(OSDCServer, self).__init__(utup, cpus, roots, credentials)
 
     def connect(self):
-        while True:
-            os.system("ssh-agent -s")
-            sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
+        os.system("ssh-agent -s")
+        sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
+        retCode = 1
+        while retCode != 0:
             os.environ['SSH_AUTH_SOCK'] = sshAgentList[0]
-            retCode = os.system("ssh-add /var/www/jongkaishackleton-www.pem")
-            if retCode == 0:
-                for i in range(1, len(sshAgentList)):
-                    agentPID = int(sshAgentList[i].split(".")[1])+1
-                    os.system("kill " + str(agentPID))
-                break
-            else:
-                agentPID = int(sshAgentList[0].split(".")[1])+1
-                # TODO: add sleep
-                os.system("kill " + str(agentPID))
+            retCode = os.system("ssh-add /home/jongkai/.ssh/jongkaishackleton.pem")
+
+        #     os.system("ssh-agent -s")
+        #     sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
+        #     os.environ['SSH_AUTH_SOCK'] = sshAgentList[0]
+        #     retCode = os.system("ssh-add /home/jongkai/.ssh/jongkaishackleton.pem")
+
+                
+
+        # while True:
+        #     os.system("ssh-agent -s")
+        #     sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
+        #     os.environ['SSH_AUTH_SOCK'] = sshAgentList[0]
+        #     retCode = os.system("ssh-add /home/jongkai/.ssh/jongkaishackleton.pem")
+        #     if retCode == 0:
+        #         for i in range(1, len(sshAgentList)):
+        #             agentPID = int(sshAgentList[i].split(".")[1])+1
+        #             os.system("kill " + str(agentPID))
+        #         break
+        #     else:
+        #         agentPID = int(sshAgentList[0].split(".")[1])+1
+        #         # TODO: add sleep
+        #         os.system("kill " + str(agentPID))
+
+        # client = paramiko.SSHClient()
+        # #proxy = paramiko.ProxyCommand('ssh -A ubuntu@' + self.credentials['instanceip'])
+        # proxy = paramiko.ProxyCommand("ssh -o StrictHostKeyChecking=no griffin.opensciencedatacloud.org nc 172.17.199.2 22")
+        # client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        # print('yo')
+        # client.connect(self.credentials['loginnode'], username=self.credentials['username'], sock=proxy)
+        # paramiko.util.log_to_file("filename.log")
+        # print("haa")
+        # s = client.get_transport().open_session()
+        # paramiko.agent.AgentRequestHandler(s)
+        # s.get_pty()
+        # s.invoke_shell()
+
+
+        # client = paramiko.SSHClient()
+        # client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        # client.connect(self.credentials['loginnode'], username=self.credentials['username'])
+        # s = client.get_transport().open_session()
+        # paramiko.agent.AgentRequestHandler(s)
+        # s.get_pty()
+        # s.invoke_shell()
+        # proxy = paramiko.ProxyCommand("ssh -o ForwardAgent griffin.opensciencedatacloud.org nc 172.17.199.2 22")
+        # client2 = paramiko.SSHClient()
+        # client2.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        # print('yo')
+        # client2.connect(self.credentials['loginnode'], username=self.credentials['username'], sock=proxy)
+        # print("haa")
+        # s2 = client.get_transport().open_session()
+        # paramiko.agent.AgentRequestHandler(s)
+        # s2.get_pty()
+        # s2.invoke_shell()
+        # pring("GO")
+        # self.client = client2
+        # self.session = s2
+        # self.connected = True
+
+        # stdout, stderr = self.run_command('date "+%H:%M:%S   %d/%m/%y" >> arrived')
+        
+        # self.receive_all()
 
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -57,7 +111,26 @@ class OSDCServer(ParamikoServer):
         print(s)
         stdout, stderr = self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
         print(self, s)
-        stdout, stderr = self.run_command('hostname > arrived')
+        stdout, stderr = self.run_command('date "+%H:%M:%S   %d/%m/%y" >> arrived')
 
         self.connected = True
 
+        # while True:
+        #     stdout, stderr = self.run_command("hostname")
+        #     if stdout != "Griffin":
+        #         self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
+        #     else:
+        #         stdout, stderr = self.run_command('date "+%H:%M:%S   %d/%m/%y" >> arrived')
+        #         return True
+
+
+    def check_connection(self):
+        if not self.connected:
+            return False
+        while True:
+            stdout, stderr = self.run_command("hostname")
+            if stdout != "Griffin":
+                self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
+                time.sleep(0.2)
+            else:
+                return True

--- a/computer/osdc_server.py
+++ b/computer/osdc_server.py
@@ -23,117 +23,62 @@ class OSDCServer(ParamikoServer):
         super(OSDCServer, self).__init__(utup, cpus, roots, credentials)
 
     def connect(self):
-        os.system("ssh-agent -s")
-        sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
+        # Logging into the OSDC server requires adding ssh identity to ssh-agent first.
+        # If there's an existing agent, just find its name and use it, instead of creating a new one.
+        # Only create a new one when all the existing ssh-agent failed.
+        # "Using" a ssh-agent means setting the shell variable SSH_AUTH_SOCK to its tmp file.
         retCode = 1
+        try_count = 0
         while retCode != 0:
-            os.environ['SSH_AUTH_SOCK'] = sshAgentList[0]
-            retCode = os.system("ssh-add /home/jongkai/.ssh/jongkaishackleton.pem")
+            sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
+            for i in len(sshAgentList):
+                os.environ['SSH_AUTH_SOCK'] = sshAgentList[i]
+                retCode = os.system("ssh-add /var/www/jongkaishackleton-www.pem")
+                if retCode == 0:
+                    break
+            if retCode != 0:
+                os.system("ssh-agent -s")
+            if try_count > 99:
+                raise SystemExit("Cannot add ssh identity!")
+            try_count += 1
 
-        #     os.system("ssh-agent -s")
-        #     sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
-        #     os.environ['SSH_AUTH_SOCK'] = sshAgentList[0]
-        #     retCode = os.system("ssh-add /home/jongkai/.ssh/jongkaishackleton.pem")
-
-                
-
-        # while True:
-        #     os.system("ssh-agent -s")
-        #     sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
-        #     os.environ['SSH_AUTH_SOCK'] = sshAgentList[0]
-        #     retCode = os.system("ssh-add /home/jongkai/.ssh/jongkaishackleton.pem")
-        #     if retCode == 0:
-        #         for i in range(1, len(sshAgentList)):
-        #             agentPID = int(sshAgentList[i].split(".")[1])+1
-        #             os.system("kill " + str(agentPID))
-        #         break
-        #     else:
-        #         agentPID = int(sshAgentList[0].split(".")[1])+1
-        #         # TODO: add sleep
-        #         os.system("kill " + str(agentPID))
-
-        # client = paramiko.SSHClient()
-        # #proxy = paramiko.ProxyCommand('ssh -A ubuntu@' + self.credentials['instanceip'])
-        # proxy = paramiko.ProxyCommand("ssh -o StrictHostKeyChecking=no griffin.opensciencedatacloud.org nc 172.17.199.2 22")
-        # client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        # print('yo')
-        # client.connect(self.credentials['loginnode'], username=self.credentials['username'], sock=proxy)
-        # paramiko.util.log_to_file("filename.log")
-        # print("haa")
-        # s = client.get_transport().open_session()
-        # paramiko.agent.AgentRequestHandler(s)
-        # s.get_pty()
-        # s.invoke_shell()
-
-
-        # client = paramiko.SSHClient()
-        # client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        # client.connect(self.credentials['loginnode'], username=self.credentials['username'])
-        # s = client.get_transport().open_session()
-        # paramiko.agent.AgentRequestHandler(s)
-        # s.get_pty()
-        # s.invoke_shell()
-        # proxy = paramiko.ProxyCommand("ssh -o ForwardAgent griffin.opensciencedatacloud.org nc 172.17.199.2 22")
-        # client2 = paramiko.SSHClient()
-        # client2.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        # print('yo')
-        # client2.connect(self.credentials['loginnode'], username=self.credentials['username'], sock=proxy)
-        # print("haa")
-        # s2 = client.get_transport().open_session()
-        # paramiko.agent.AgentRequestHandler(s)
-        # s2.get_pty()
-        # s2.invoke_shell()
-        # pring("GO")
-        # self.client = client2
-        # self.session = s2
-        # self.connected = True
-
-        # stdout, stderr = self.run_command('date "+%H:%M:%S   %d/%m/%y" >> arrived')
-        
-        # self.receive_all()
-
+        # Other setups are similar to using paramiko to login to shackleton.
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        # ssh -A jrising@griffin.opensciencedatacloud.org
         client.connect(self.credentials['loginnode'], username=self.credentials['username'])
-
-        # Open up a session
         s = client.get_transport().open_session()
         paramiko.agent.AgentRequestHandler(s)
-
         s.get_pty()
         s.invoke_shell()
-
         self.client = client
         self.session = s
 
-        # ssh -A ubuntu@172.17.199.2
-        print(s)
+        # Except for having to manually login into computation node.
         stdout, stderr = self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
-        print(self, s)
         stdout, stderr = self.run_command('date "+%H:%M:%S   %d/%m/%y" >> arrived')
 
         self.connected = True
 
-        # while True:
-        #     stdout, stderr = self.run_command("hostname")
-        #     if stdout != "Griffin":
-        #         self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
-        #     else:
-        #         stdout, stderr = self.run_command('date "+%H:%M:%S   %d/%m/%y" >> arrived')
-        #         return True
-
-
     def check_connection(self):
+        # This method checks both the connection to login node and the computation node.
+        # If connection to computation node is dropped, retry.
+        # But not worry about reconnection to login node, which would be handle by the caller.
+        # This design is for the consistency of caller's behavior.
         if not self.connected:
             return False
         while True:
+            # Log the arrive time for manual checking, if this time info appears in login node,
+            # then I know the connection to computation node had dropped;
+            # if this info appears in shackleton, then I know that not only the connection to login node had dropped, 
+            # but also the self.connected is not performing as expected.
+            self.run_command('date "+%H:%M:%S   %d/%m/%y" >> arrived')
+
+            # If hostname is shackleton, then the connection to login node is dropped, should reconnect.
             stdout, stderr = self.run_command("hostname")
-            print stdout
-            print(stdout =="conflicts")
-            print('ssh -A ubuntu@' + self.credentials['instanceip'])
-            if stdout != "conflicts":
+            if stdout == "shackleton":
+                return False
+            elif stdout == "conflicts":
+                return True
+            else:
                 self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
                 time.sleep(0.2)
-            else:
-                return True

--- a/computer/osdc_server.py
+++ b/computer/osdc_server.py
@@ -1,0 +1,63 @@
+import paramiko, os
+from paramiko_server import ParamikoServer
+from process import SingleCPUProcess
+
+
+class OSDCProcess(SingleCPUProcess):
+    def __init__(self, pid, logfile):
+        super(OSDCProcess, self).__init__(logfile)
+        self.pid = pid
+
+    def is_running(self):
+        raise NotImplementedError("Not implemented yet.")
+
+    def kill(self):
+        raise NotImplementedError("Not implemented yet.")
+
+    def clean(self):
+        raise NotImplementedError("Not implemented yet.")
+
+
+class OSDCServer(ParamikoServer):
+    def __init__(self, utup, cpus, roots, credentials):
+        super(OSDCServer, self).__init__(utup, cpus, roots, credentials)
+
+    def connect(self):
+        while True:
+            os.system("ssh-agent -s")
+            sshAgentList = os.popen("find /tmp/ -type s -name agent.* 2>/dev/null | grep '/tmp/ssh-.*/agent.*'").read().split("\n")[:-1]
+            os.environ['SSH_AUTH_SOCK'] = sshAgentList[0]
+            retCode = os.system("ssh-add /var/www/jongkaishackleton-www.pem")
+            if retCode == 0:
+                for i in range(1, len(sshAgentList)):
+                    agentPID = int(sshAgentList[i].split(".")[1])+1
+                    os.system("kill " + str(agentPID))
+                break
+            else:
+                agentPID = int(sshAgentList[0].split(".")[1])+1
+                # TODO: add sleep
+                os.system("kill " + str(agentPID))
+
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        # ssh -A jrising@griffin.opensciencedatacloud.org
+        client.connect(self.credentials['loginnode'], username=self.credentials['username'])
+
+        # Open up a session
+        s = client.get_transport().open_session()
+        paramiko.agent.AgentRequestHandler(s)
+
+        s.get_pty()
+        s.invoke_shell()
+
+        self.client = client
+        self.session = s
+
+        # ssh -A ubuntu@172.17.199.2
+        print(s)
+        stdout, stderr = self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
+        print(self, s)
+        stdout, stderr = self.run_command('hostname > arrived')
+
+        self.connected = True
+

--- a/computer/osdc_server.py
+++ b/computer/osdc_server.py
@@ -1,4 +1,4 @@
-import paramiko, os
+import paramiko, os, time
 from paramiko_server import ParamikoServer
 from process import SingleCPUProcess
 
@@ -129,7 +129,10 @@ class OSDCServer(ParamikoServer):
             return False
         while True:
             stdout, stderr = self.run_command("hostname")
-            if stdout != "Griffin":
+            print stdout
+            print(stdout =="conflicts")
+            print('ssh -A ubuntu@' + self.credentials['instanceip'])
+            if stdout != "conflicts":
                 self.run_command('ssh -A ubuntu@' + self.credentials['instanceip'])
                 time.sleep(0.2)
             else:


### PR DESCRIPTION
Before looking into how this class is implemented, the reader should look at login_server.py to see an easier implementation.

Logging into the OSDC server is a two-stages process:
1. Logging into griffin, the login node
2. From griffin, do a run_command to get into the computation node. This step is presumably less reliable, as it is not handled by paramiko as normal. But we do this regardless for current stage due to the fact that we have less control over Shackleton and that we don't really know how to implement port-forwarding safely with our current privileges.

Since there are two stages of connecting, for the consistency of caller's behavior, this method would handle the connection for both stages. It will first check the hostname of the current machine, then decide what to do accordingly.

Also, the way we forward authentication agent requires adding ssh identity to ssh-agent first.
Here's how we do this:
1. If there's an existing agent, just find its name and use it, instead of creating a new one.
2. Only create a new one when all the existing ssh-agent failed.
3. "Using" a ssh-agent means setting the shell variable SSH_AUTH_SOCK to its tmp file.
